### PR TITLE
bugfix not_platform spec

### DIFF
--- a/spec/not_platform_spec.rb
+++ b/spec/not_platform_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe PlatformSH do
   before(:all) do
       @config = PlatformSH::config


### PR DESCRIPTION
`/Users/jgrubb/.rbenv/versions/2.3.1/bin/ruby -I/Users/jgrubb/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-support-3.5.0/lib:/Users/jgrubb/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.3/lib /Users/jgrubb/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/rspec-core-3.5.3/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
/Users/jgrubb/work/ruby/platformsh-ruby-helper/spec/not_platform_spec.rb:1:in`<top (required)>': uninitialized constant PlatformSH (NameError)
`

Missing require at top of not_platform spec.
