### PR TITLE
Remove Ruby 2.3 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.3, 2.4, 2.5, 2.6, 2.7]
+        ruby: [2.4, 2.5, 2.6, 2.7]
 
     steps:
     - uses: actions/checkout@v2

--- a/platform.gemspec
+++ b/platform.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+  spec.required_ruby_version = '>= 2.4'
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Was expecting to fail so lets not put to much effort on supporting end of life version